### PR TITLE
Safely update and install packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,14 @@
 FROM ubuntu:13.10
 MAINTAINER Zaiste <oh [at] zaiste.net>
 
-RUN apt-get update
-RUN apt-get -y install wget git
-
-RUN apt-get install -q -y openjdk-7-jre-headless && apt-get clean
-
-RUN echo "deb http://pkg.jenkins-ci.org/debian binary/" > /etc/apt/sources.list.d/jenkins.list
-RUN wget -q -O - http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key | apt-key add -
-RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y jenkins
+RUN apt-get update \
+  && apt-get -q -y install wget git openjdk-7-jre-headless \
+  && echo "deb http://pkg.jenkins-ci.org/debian binary/" > /etc/apt/sources.list.d/jenkins.list \
+  && wget -q -O - http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key | apt-key add - \
+  && apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y jenkins \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/
 
 VOLUME /var/lib/jenkins
 ENV JENKINS_HOME /var/lib/jenkins


### PR DESCRIPTION
Having the apt-get update and then install in separate RUN statements potentially means the install will fail, despite the presence of the update. One-lining the build here should fix that.
