### PR TITLE
Zaiste

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:13.10
+FROM buildpack-deps
 MAINTAINER Zaiste <oh [at] zaiste.net>
 
 RUN apt-get update \

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ following plugins:
 Usage
 -----
 
-    docker run -d -t zaiste/jenkins
+    docker run -d -t -p 8080:8080 -v ${PWD}:/var/lib/jenkins zaiste/jenkins
 
 Building
 --------
@@ -34,4 +34,11 @@ Get a Docker image from Docker index
 
     docker pull zaiste/jenkins
 
+Testing
+-------
 
+Install [docker-test](https://github.com/wblankenship/docker-test)
+
+From within the clone repo
+
+    docker-test

--- a/inventory.yml
+++ b/inventory.yml
@@ -1,4 +1,4 @@
 images:
-  - name: wblankenship/jenkins
+  - name: zaiste/jenkins
     path: "./"
     test: ["./tests/jenkins"]

--- a/inventory.yml
+++ b/inventory.yml
@@ -1,0 +1,4 @@
+images:
+  - name: wblankenship/jenkins
+    path: "./"
+    test: ["./tests/jenkins"]

--- a/tests/jenkins/Dockerfile
+++ b/tests/jenkins/Dockerfile
@@ -1,0 +1,4 @@
+# Ensure Jenkins starts and runs
+RUN java -jar /usr/share/jenkins/jenkins.war& \
+    sleep 1m && \
+    curl http://127.0.0.1:8080


### PR DESCRIPTION
Moved to `buildpack-deps` since Saucy is no longer supported. `buildpack-deps` is used by the official images.

Updated readme to include port and volume.

Added simple test to ensure Jenkins can start in the environment.
